### PR TITLE
Only load TerminalExtensions if there is a REPL

### DIFF
--- a/src/TerminalExtensions.jl
+++ b/src/TerminalExtensions.jl
@@ -183,7 +183,7 @@ module iTerm2
 end
 
 function __init__()
-    if !isinteractive()
+    if !(isinteractive() && isdefined(Base, :active_repl))
         return
     end
     # print, but hide initial mark, even before we know we're dealing with iterm


### PR DESCRIPTION
This is required to get the Julia cmdlineargs test to pass if `using TerminalExtensions` is in your .juliarc.jl file.  It also makes sense... We may want to go one step farther and require that the active_repl be a LineEditREPL.