### PR TITLE
Drop Compat requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.5
   - nightly
 #script:
 #  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("TerminalExtensions")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5-
-Compat
+julia 0.5

--- a/src/TerminalExtensions.jl
+++ b/src/TerminalExtensions.jl
@@ -1,6 +1,5 @@
 module TerminalExtensions
 
-using Compat
 #
 # None of these functions are operating system specific because they
 # might be connect via e.g. SSH to a different client operating system
@@ -34,7 +33,6 @@ end
 module iTerm2
 
     import Base: display
-    using Compat
 
     immutable InlineDisplay <: Display; end
 


### PR DESCRIPTION
should not be necessary any more, was added in https://github.com/Keno/TerminalExtensions.jl/pull/6 for `sizehint!`

also drop support for prereleases of Julia 0.5

turn on 0.5 release testing on Travis (needs to be enabled, and some tests should be written)