### PR TITLE
Send shell integration version number and shell name

### DIFF
--- a/src/TerminalExtensions.jl
+++ b/src/TerminalExtensions.jl
@@ -58,7 +58,7 @@ module iTerm2
     end
 
     function shell_version_number()
-        return "\033]1337;ShellIntegrationVersion=1\007"
+        return "\033]1337;ShellIntegrationVersion=1;shell=julia\007"
     end
 
 
@@ -132,6 +132,9 @@ function __init__()
 
 
         if startswith(itermname, "ITERM2")
+            # Inform iTerm of the shell integration version and that we're julia
+            write(STDOUT, iTerm2.shell_version_number())
+
             pushdisplay(iTerm2.InlineDisplay())
             repl = Base.active_repl#REPL.LineEditREPL(Terminals.TTYTerminal("xterm",STDIN,STDOUT,STDERR))
 


### PR DESCRIPTION
As requested in #34. @gnachman let me know if this is what you had in mind. As you suggested, this sends `"\033]1337;ShellIntegrationVersion=1;shell=julia\007"` after detecting iTerm2 support. Alternatively, I could send it before every prompt if that would help you distinguish situations where both julia and bash are active (e.g. I'm imagining a situation where somebody might run an interactive subprocess that itself has shell integration). Let me know what you prefer.